### PR TITLE
Fix creating large integers of more than 4 bytes

### DIFF
--- a/mc/VMMaker.oscog.package/StackInterpreter.class/instance/noInlineSigned32BitIntegerFor..st
+++ b/mc/VMMaker.oscog.package/StackInterpreter.class/instance/noInlineSigned32BitIntegerFor..st
@@ -2,26 +2,33 @@ primitive support
 noInlineSigned32BitIntegerFor: integerValue
 	"Answer a full 32 bit integer object for the given integer value."
 	<notOption: #Spur64BitMemoryManager>
-	| newLargeInteger magnitude largeClass |
+	| newLargeInteger magnitude largeClass numberOfSlots |
 	<inline: false>
 	<var: 'magnitude' type: 'unsigned int'>
 	(objectMemory isIntegerValue: integerValue) ifTrue:
 		[^objectMemory integerObjectOf: integerValue].
 	self deny: objectMemory hasSixtyFourBitImmediates.
+
 	 integerValue < 0
-		ifTrue: [largeClass := ClassLargeNegativeIntegerCompactIndex.
+		ifTrue: [
+			largeClass := ClassLargeNegativeIntegerCompactIndex.
 				magnitude := 0 asUnsignedInteger - integerValue]
 		ifFalse: [largeClass := ClassLargePositiveIntegerCompactIndex.
 				magnitude := integerValue].
+	numberOfSlots := (integerValue digitLength / objectMemory bytesPerOop) ceiling.
 	newLargeInteger := objectMemory
 							eeInstantiateSmallClassIndex: largeClass
-							format: (objectMemory byteFormatForNumBytes: 4)
-							numSlots: 1.
+							format: (objectMemory byteFormatForNumBytes: integerValue digitLength)
+							numSlots: numberOfSlots.
 	SPURVM
 		ifTrue:
 			["Memory is 8 byte aligned in Spur, make sure that oversized bytes are set to zero" "eem 4/28/2016 questionable; they should never be read"
-			objectMemory storeLong32: 0 ofObject: newLargeInteger withValue: (objectMemory byteSwapped32IfBigEndian: magnitude).
-			objectMemory storeLong32: 1 ofObject: newLargeInteger withValue: 0]
+			0 to: numberOfSlots - 1 do: [ :index |
+				objectMemory
+					storeLong32: index
+					ofObject: newLargeInteger
+					withValue: (objectMemory byteSwapped32IfBigEndian: magnitude >> (index * 32)) ]
+			]
 		ifFalse: 
 			[objectMemory storeLong32: 0 ofObject: newLargeInteger withValue: (objectMemory byteSwapped32IfBigEndian: magnitude)].
 	^newLargeInteger


### PR DESCRIPTION
Fixed noInlineSigned32BitIntegerFor. Large integers are not correctly instantiated with the right size, and they do not have their fields correctly set if they are longer than 4 bytes.